### PR TITLE
add sloglint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for contributing to this project! ❤️
 
-Please take a few minutes to read this guide before opening an pull request.
+Please take a few minutes to read this guide before opening a pull request.
 
 The purpose of this project is to help people find resources related to the recently
 (as of the time of this writing) added `log/slog` package to the standard library.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ _General purpose handlers and integrations._
 
 - [slog-multi](https://github.com/samber/slog-multi): Chaining handlers (pipe, router, fanout, etc).
 - [slog-sampling](https://github.com/samber/slog-sampling): Drop repetitive log entries.
-- [sloggen](https://github.com/go-simpler/sloggen): Generate custom attributes.
 - [slog-shim](https://github.com/sagikazarmark/slog-shim): Backward compatible slog support for Go <1.21.
+- [sloggen](https://github.com/go-simpler/sloggen): Generate various helpers.
+- [sloglint](https://github.com/go-simpler/sloglint): Ensure consistent code style.
 
 **[⬆ back to top](#contents)**
 

--- a/data.yaml
+++ b/data.yaml
@@ -10,14 +10,18 @@ categories:
         link: https://github.com/samber/slog-sampling
         description: Drop repetitive log entries.
 
-      # Potential new category: Extensions?
-      - name: sloggen
-        link: https://github.com/go-simpler/sloggen
-        description: Generate custom attributes.
-
       - name: slog-shim
         link: https://github.com/sagikazarmark/slog-shim
         description: Backward compatible slog support for Go <1.21.
+
+      # Potential new category: Extensions?
+      - name: sloggen
+        link: https://github.com/go-simpler/sloggen
+        description: Generate various helpers.
+
+      - name: sloglint
+        link: https://github.com/go-simpler/sloglint
+        description: Ensure consistent code style.
 
   - name: Formatting
     description: Record and output formatters.


### PR DESCRIPTION
Thank you for creating this list (and adding `sloggen`) ❤️

I'd like to add another project of mine, a linter that ensures consistent code style when using `log/slog`.

I've also updated the description for `sloggen` and rearranged the list alphabetically.