### PR TITLE
Update go wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ _Other resources about `log/slog`._
 
 - [Reference documentation](https://pkg.go.dev/log/slog)
 - [Introductory blog post](https://go.dev/blog/slog)
-- [Golang Wiki page](https://github.com/golang/go/wiki/Resources-for-slog)
+- [Golang Wiki page](https://go.dev/wiki/Resources-for-slog)
 
 **[⬆ back to top](#contents)**
 

--- a/data.yaml
+++ b/data.yaml
@@ -194,7 +194,7 @@ categories:
         description:
 
       - name: Golang Wiki page
-        link: https://github.com/golang/go/wiki/Resources-for-slog
+        link: https://go.dev/wiki/Resources-for-slog
         description:
 
     categories:


### PR DESCRIPTION
From [the original link](https://github.com/golang/go/wiki/Resources-for-slog) one can read that

> The Go wiki on GitHub has moved to go.dev

so this PR updates the link to the corresponding page at the new wiki location.