### PR TITLE
add slogscope to "General" category

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -22,6 +22,10 @@ categories:
         link: https://github.com/delicb/slogbuffer
         description: Buffer log records until real handler is defined.
 
+      - name: slogscope
+        link: https://github.com/apperia-de/slogscope
+        description: Package based log levels for more fine grained control over logging behavior in large project.
+
       # Potential new category: Extensions?
       - name: sloggen
         link: https://github.com/go-simpler/sloggen


### PR DESCRIPTION
I created a slog handler called _slogscope_ for package based logging with slog. Maybe it is useful for other people as well, so I thought, your repository might be the right place for other people to find it.