### PR TITLE
feat: add slog-gokit adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ _Adapters for other logging libraries._
 - [slog-zap](https://github.com/samber/slog-zap): Handler adapter for zap.
 - [slog-zerolog](https://github.com/samber/slog-zerolog): Handler adapter for zerolog.
 - [zaphandler](https://github.com/chanchal1987/zaphandler): Handler adapter for Zap.
+- [slog-gokit](https://github.com/tjhop/slog-gokit): Go slog handler adapter for go-kit/log.
 
 **[⬆ back to top](#contents)**
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ _Adapters for other logging libraries._
 
 - [go-hclog-slog](https://github.com/evanphx/go-hclog-slog): Handler adapter for hclog.
 - [gslog](https://github.com/maguro/gslog): Handler adapter for Google Cloud Logging.
+- [slog-gokit](https://github.com/tjhop/slog-gokit): Go slog handler adapter for go-kit/log.
 - [slog-logrus](https://github.com/samber/slog-logrus): Handler adapter for logrus.
 - [slog-zap](https://github.com/samber/slog-zap): Handler adapter for zap.
 - [slog-zerolog](https://github.com/samber/slog-zerolog): Handler adapter for zerolog.
 - [zaphandler](https://github.com/chanchal1987/zaphandler): Handler adapter for Zap.
-- [slog-gokit](https://github.com/tjhop/slog-gokit): Go slog handler adapter for go-kit/log.
 
 **[⬆ back to top](#contents)**
 

--- a/data.yaml
+++ b/data.yaml
@@ -199,6 +199,10 @@ categories:
         link: https://github.com/chanchal1987/zaphandler
         description: Handler adapter for Zap.
 
+      - name: slog-gokit
+        link: https://github.com/tjhop/slog-gokit
+        description: Go slog handler adapter for go-kit/log.
+
   - name: Integrations
     description: "`log/slog` integrations into third-party components."
     items:

--- a/data.yaml
+++ b/data.yaml
@@ -183,6 +183,10 @@ categories:
         link: https://github.com/maguro/gslog
         description: Handler adapter for Google Cloud Logging.
 
+      - name: slog-gokit
+        link: https://github.com/tjhop/slog-gokit
+        description: Go slog handler adapter for go-kit/log.
+
       - name: slog-logrus
         link: https://github.com/samber/slog-logrus
         description: Handler adapter for logrus.
@@ -198,10 +202,6 @@ categories:
       - name: zaphandler
         link: https://github.com/chanchal1987/zaphandler
         description: Handler adapter for Zap.
-
-      - name: slog-gokit
-        link: https://github.com/tjhop/slog-gokit
-        description: Go slog handler adapter for go-kit/log.
 
   - name: Integrations
     description: "`log/slog` integrations into third-party components."


### PR DESCRIPTION
slog-gokit is an adapter library that allows for creating an slog Logger
that writes to an underlying go-kit/log Logger.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
