### PR TITLE
Add Last9 slog guide to Blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ _Other resources about `log/slog`._
 
 _Blog posts about `log/slog`._
 
-- [Logging in Go with Slog](https://last9.io/blog/logging-in-go-with-slog/): Comprehensive guide covering slog basics, custom handlers, and production patterns.
+- [Logging in Go with Slog](https://last9.io/blog/logging-in-go-with-slog-a-detailed-guide/): Comprehensive guide covering slog basics, custom handlers, and production patterns.
 
 **[⬆ back to top](#contents)**
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ _Other resources about `log/slog`._
 
 _Blog posts about `log/slog`._
 
+- [Logging in Go with Slog](https://last9.io/blog/logging-in-go-with-slog/): Comprehensive guide covering slog basics, custom handlers, and production patterns.
 
 **[⬆ back to top](#contents)**
 

--- a/data.yaml
+++ b/data.yaml
@@ -275,7 +275,10 @@ categories:
     categories:
       - name: Blog posts
         description: "Blog posts about `log/slog`."
-        items: []
+        items:
+          - name: Logging in Go with Slog
+            link: https://last9.io/blog/logging-in-go-with-slog/
+            description: Comprehensive guide covering slog basics, custom handlers, and production patterns.
 
       - name: Creating slog
         description: "Resources documenting the creation of `log/slog`."

--- a/data.yaml
+++ b/data.yaml
@@ -277,7 +277,7 @@ categories:
         description: "Blog posts about `log/slog`."
         items:
           - name: Logging in Go with Slog
-            link: https://last9.io/blog/logging-in-go-with-slog/
+            link: https://last9.io/blog/logging-in-go-with-slog-a-detailed-guide/
             description: Comprehensive guide covering slog basics, custom handlers, and production patterns.
 
       - name: Creating slog


### PR DESCRIPTION
Adds a comprehensive slog tutorial to the Blog posts section (currently empty).

**Resource:** [Logging in Go with Slog](https://last9.io/blog/logging-in-go-with-slog-a-detailed-guide/)

The guide covers:
- slog basics and structured logging fundamentals
- Built-in handlers (TextHandler, JSONHandler)
- Custom handler implementation
- Production patterns and best practices
- Context-aware logging

This is the first entry in the Blog posts category, which helps the community find educational resources beyond the official documentation.